### PR TITLE
fixed tv: true, added power_on and power_off, updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ https://twitter.com/_developit/status/1090364879377260544
 | name | string | **Optional** | Card name
 | theme | string | **Optional** | Card theme
 | tv | boolean | **Optional** | If `true` shows volume and power buttons. Default `false`
-| power | `service` | **Optional**| service to call when power button pressed
-| volume_up | `service` | **Optional**| service to call when volume_up button pressed
-| volume_down | `service` | **Optional**| service to call when volume_down button pressed
+| power | `service` | **Optional, Exclusive**| service to call when power button pressed. When `power` defined, `power_on` and `power_off` are disabled, even when defined
+| power_on | `service` | **Optional, Exclusive**| service to call when power_on button pressed. Only enabled if no `power` defined.
+| power_off | `service` | **Optional, Exclusive**| service to call when power_off button pressed. Only enabled if no `power` defined.
 | back | `service` | **Optional**| service to call when back button pressed
 | info        | `service` | **Optional**| service to call when info button pressed
 | home | `service` | **Optional**| service to call when home button pressed

--- a/tv-card.js
+++ b/tv-card.js
@@ -57,7 +57,7 @@ class TVCardServices extends LitElement {
 
           </div>
           ${
-            this._config.power
+            this._config.tv && this._config.power
               ? html`
                   <div class="row">
                     <ha-icon-button
@@ -72,6 +72,28 @@ class TVCardServices extends LitElement {
                       @click="${this.handleActionClick}"
                       icon="mdi:power"
                       title="Power"
+                    ></ha-icon-button>
+                  </div>
+                `
+              : ""
+          }
+
+          ${
+            this._config.tv && !(this._config.power) && (this._config.power_on || this._config.power_off)
+              ? html`
+                  <div class="row">
+                    <ha-icon-button
+                      .action="${"power_on"}"
+                      @click="${this.handleActionClick}"
+                      icon="mdi:power-on"
+                      title="Power on"
+                    ></ha-icon-button>
+                    ${emptyButton}
+                    <ha-icon-button
+                      .action="${"power_off"}"
+                      @click="${this.handleActionClick}"
+                      icon="mdi:power-off"
+                      title="Power off"
                     ></ha-icon-button>
                   </div>
                 `
@@ -237,10 +259,10 @@ class TVCardServices extends LitElement {
           }
 
           ${
-            this._config.tv ||
+            this._config.tv && (
             this._config.volume_up ||
             this._config.volume_down ||
-            this._config.volume_mute
+            this._config.volume_mute )
               ? html`
                   <div class="row">
                     <ha-icon-button
@@ -316,6 +338,8 @@ class TVCardServices extends LitElement {
   handleActionClick(e) {
     const custom_services = [
       "power",
+      "power_on",
+      "power_off",
       "volume_up",
       "volume_down",
       "volume_mute",


### PR DESCRIPTION
I've separated power button (as requested in #9) but without making it a breaking change. `power` is still primary way of defining power action but there is a possibility to override default `power` action with `power_on` and `power_off`.
Fixed `tv` to handle showing and hiding power and volume buttons.
Updated README.md with new options and removed doubled `volume_up`, `volume_down` rows in table.