### PR TITLE
Fix browser_mod example

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ entities:
   - entity: input_boolean.tv
     name: TV
     tap_action:
-      action: call-service
-      service: browser_mod.popup
-      service_data:
+      action: fire-dom-event
+      browser_mod:
+        command: popup
         style:
           border-radius: 20px
           '--ha-card-border-radius': 0px


### PR DESCRIPTION
Hi! 

I have been using this card for some time and today, when I started using it with browser_mod as you suggest in the example, I found the problem that the pop-up was opening on all devices.

That is caused because the method "call-service" + "browser_mod.popup" is going to open the popup in all devices. Instead of, I should use "fire-dom-event" + "popup" to only open in the current device.
